### PR TITLE
Fix: add static/app.js, wire showApiKeyModal, and harden /api/prompt JSON handling

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,135 @@
+(function () {
+  function getStorage() {
+    try {
+      return window.localStorage;
+    } catch (err) {
+      console.error('localStorage is unavailable', err);
+      return null;
+    }
+  }
+
+  function toProviderKey(provider) {
+    const normalized = typeof provider === 'string' ? provider.trim() : '';
+    return normalized ? `${normalized.toUpperCase()}_API_KEY` : 'API_KEY';
+  }
+
+  window.getApiKey = function (provider) {
+    const storage = getStorage();
+    if (!storage) {
+      return '';
+    }
+
+    const providerKey = typeof provider === 'string' && provider.trim()
+      ? `${provider.trim().toUpperCase()}_API_KEY`
+      : null;
+
+    if (providerKey) {
+      const specific = storage.getItem(providerKey);
+      if (typeof specific === 'string' && specific) {
+        return specific;
+      }
+    }
+
+    return storage.getItem('API_KEY') || '';
+  };
+
+  window.showApiKeyModal = function (llmChoice) {
+    const storage = getStorage();
+    const keyName = toProviderKey(llmChoice);
+    const providerName = typeof llmChoice === 'string' && llmChoice.trim()
+      ? llmChoice.trim().toUpperCase()
+      : '';
+    const promptLabel = providerName
+      ? `Enter your API key for ${providerName}:`
+      : 'Enter your API key:';
+
+    const existingValue = storage ? storage.getItem(keyName) || '' : '';
+    const input = window.prompt(promptLabel, existingValue);
+    if (input === null) {
+      return '';
+    }
+
+    const value = input.trim();
+    if (!value) {
+      alert('API key not saved: empty input.');
+      return '';
+    }
+
+    if (!storage) {
+      alert('Unable to access localStorage.');
+      return '';
+    }
+
+    try {
+      storage.setItem(keyName, value);
+      alert('Saved.');
+    } catch (err) {
+      console.error('Failed to persist API key', err);
+      alert('Failed to save API key.');
+      return '';
+    }
+
+    return value;
+  };
+
+  window.hideApiKeyModal = function () {
+    const modal = document.getElementById('api-key-modal');
+    if (modal) {
+      modal.style.display = 'none';
+    }
+  };
+
+  window.submitApiKey = function () {
+    const storage = getStorage();
+    if (!storage) {
+      alert('Unable to access localStorage.');
+      return;
+    }
+
+    const input = document.getElementById('api-key-input');
+    const value = input && typeof input.value === 'string' ? input.value.trim() : '';
+    if (!value) {
+      alert('Please enter an API key.');
+      return;
+    }
+
+    const provider = document.querySelector('input[name="llm-choice"]:checked')?.value || '';
+    const keyName = toProviderKey(provider);
+
+    try {
+      storage.setItem(keyName, value);
+      alert('Saved.');
+      if (input) {
+        input.value = '';
+      }
+      window.hideApiKeyModal();
+    } catch (err) {
+      console.error('Failed to persist API key', err);
+      alert('Failed to save API key.');
+    }
+  };
+
+  window.sendPrompt = async function ({ prompt, provider = 'openai' } = {}) {
+    const apiKey = window.getApiKey(provider);
+    const response = await fetch('/api/prompt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt, provider, apiKey })
+    });
+
+    let data = {};
+    try {
+      data = await response.json();
+    } catch (err) {
+      data = {};
+    }
+
+    if (!response.ok) {
+      console.error('Request failed', data);
+      alert((data && data.error) || 'Request failed');
+    }
+
+    return data;
+  };
+})();
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -432,43 +432,46 @@
         currentLLMChoice = llmChoice;
         currentPrompt = value;
 
-        // Clear output and show a small spinner text
+        const provider = llmChoice || 'openai';
+        const payload = {
+          prompt: value,
+          provider,
+          apiKey: typeof window.getApiKey === 'function' ? window.getApiKey(provider) : '',
+          llm_choice: llmChoice
+        };
+
         setOutput('');
 
         try {
           const res = await fetch('/api/prompt', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ prompt: value, llm_choice: llmChoice })
+            body: JSON.stringify(payload)
           });
 
-          // If API key missing, server returns JSON error; handle that first.
           const contentType = res.headers.get('content-type') || '';
-          if (!res.ok && contentType.includes('application/json')) {
-            const payload = await res.json();
-            if (payload && payload.error === 'NO API key set.') {
-              showApiKeyModal(llmChoice);
+          const isJson = contentType.includes('application/json');
+          const body = isJson ? await res.json() : await res.text();
+
+          if (!res.ok) {
+            const errorMessage = isJson ? (body?.error || '') : '';
+            const missingKeyError = typeof errorMessage === 'string' && errorMessage.toLowerCase().includes('api key');
+            if (missingKeyError && typeof window.showApiKeyModal === 'function') {
+              window.showApiKeyModal(provider);
               return;
             }
-            throw new Error(payload?.error || 'Request failed');
+            throw new Error(errorMessage || 'Request failed');
           }
 
-          // Stream plain text chunks and append to the output box
-          const reader = res.body?.getReader();
-          const decoder = new TextDecoder();
-          if (!reader) {
-            throw new Error('Streaming not supported by this browser.');
-          }
-
-          while (true) {
-            const { done, value: chunk } = await reader.read();
-            if (done) break;
-            const text = decoder.decode(chunk, { stream: true });
-            if (text) appendOutput(text);
+          if (isJson) {
+            const output = typeof body.output === 'string' ? body.output : '';
+            setOutput(output || '[No output returned]');
+          } else {
+            setOutput(typeof body === 'string' ? body : '[No output returned]');
           }
         } catch (err) {
-          console.error('Error streaming prompt:', err);
-          appendOutput('\\n[Error] ' + (err?.message || String(err)));
+          console.error('Error submitting prompt:', err);
+          setOutput('[Error] ' + (err?.message || String(err)));
         }
       }
       
@@ -491,20 +494,32 @@
       const apiKeyInput = document.getElementById('api-key-input');
 
       if (cancelButton) {
-        cancelButton.addEventListener('click', hideApiKeyModal);
+        cancelButton.addEventListener('click', function () {
+          if (typeof window.hideApiKeyModal === 'function') {
+            window.hideApiKeyModal();
+          }
+        });
       }
 
       if (submitButton) {
-        submitButton.addEventListener('click', submitApiKey);
+        submitButton.addEventListener('click', function () {
+          if (typeof window.submitApiKey === 'function') {
+            window.submitApiKey();
+          }
+        });
       }
 
       if (apiKeyInput) {
         apiKeyInput.addEventListener('keydown', function (e) {
           if (e.key === 'Enter') {
             e.preventDefault();
-            submitApiKey();
+            if (typeof window.submitApiKey === 'function') {
+              window.submitApiKey();
+            }
           } else if (e.key === 'Escape') {
-            hideApiKeyModal();
+            if (typeof window.hideApiKeyModal === 'function') {
+              window.hideApiKeyModal();
+            }
           }
         });
       }
@@ -547,5 +562,6 @@
       }
     })();
   </script>
+  <script src="{{ url_for('static', filename='app.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a dedicated `static/app.js` bundle that exposes API-key helpers and a reusable `sendPrompt` fetch wrapper
- update the index template to use provider-aware JSON payloads, guard modal listeners, and load the new script
- harden `/api/prompt` to validate JSON input, prefer environment API keys, and return predictable JSON responses

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68eeb42ff4288328b1ebf33219f1bae0