### PR TITLE
Add backend RAG context buffer and document extraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ flask==3.1.2
 langgraph==0.6.8
 langchain_google_genai==2.1.12
 langchain_openai==0.3.35
+pypdf==5.1.0
+python-docx==1.1.2
+python-pptx==1.0.2
+beautifulsoup4==4.12.3
+lxml==5.3.0


### PR DESCRIPTION
## Summary
- add document text extraction helpers for PDF, DOCX, PPTX, HTML, TXT/MD uploads and store results in an in-memory context buffer
- prepend the stored context when prompting the LLM and expose endpoints to inspect or clear the buffer
- include the required third-party libraries for document parsing in the backend dependencies

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68eebd10dbd08328baab0feeb2669c04