### PR TITLE
Add planner entry point to homepage

### DIFF
--- a/app.py
+++ b/app.py
@@ -169,6 +169,12 @@ def index():
     """ Render the index.html template """
     return render_template("index.html")
 
+
+@app.route("/planner")
+def planner():
+    """ Render the planner.html template """
+    return render_template("planner.html")
+
 def _message_to_text(msg) -> str:
     """Extract plain text from message content which can be a str or list of parts."""
     try:

--- a/static/styles.css
+++ b/static/styles.css
@@ -83,6 +83,9 @@ input[type="file"] {
 }
 
 button, .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 12px 30px;
   border: none;
   border-radius: 50px;
@@ -92,6 +95,18 @@ button, .btn {
   cursor: pointer;
   transition: all 0.3s ease;
   box-shadow: 0 2px 10px rgba(52, 152, 219, 0.08);
+}
+
+.btn.secondary {
+  background: transparent;
+  color: #3498db;
+  border: 2px solid #3498db;
+  box-shadow: none;
+}
+
+.btn.secondary:hover {
+  background: rgba(52, 152, 219, 0.1);
+  color: #2980b9;
 }
 
 button:hover, .btn:hover {
@@ -400,6 +415,95 @@ button:active {
 button:focus-visible {
   outline: 3px solid rgba(56, 189, 248, 0.5);
   outline-offset: 4px;
+}
+
+.page-links {
+  margin-top: 1.5rem;
+}
+
+.planner-container {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+.planner-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+@media (min-width: 768px) {
+  .planner-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.planner-title-group {
+  max-width: 720px;
+}
+
+.planner-intro {
+  color: #555;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.planner-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 992px) {
+  .planner-grid {
+    grid-template-columns: 3fr 2fr;
+    align-items: start;
+  }
+}
+
+.planner-map {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.planner-section-label {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #2c3e50;
+}
+
+.map-placeholder {
+  min-height: 360px;
+  border: 2px dashed #b0c4de;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(231, 242, 255, 0.6), rgba(215, 227, 252, 0.6));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #54739c;
+  font-weight: 600;
+  text-align: center;
+  padding: 1.5rem;
+}
+
+.planner-caption {
+  color: #6b7a8f;
+  font-size: 0.95rem;
+}
+
+.planner-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.planner-form textarea {
+  min-height: 240px;
+  resize: vertical;
 }
 
 .output-box {

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -30,11 +30,8 @@
       </div>
 
       <div class="actions homepage-actions">
-        <a href="{{ url_for('index') }}" class="btn-primary">
-          <button id="enter-app-button" type="button" aria-label="Enter Application">
-            Get Started
-          </button>
-        </a>
+        <a href="{{ url_for('index') }}" class="btn">Get Started</a>
+        <a href="{{ url_for('planner') }}" class="btn secondary">Try Campus Path Planner</a>
       </div>
     </section>
   </main>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,8 +11,13 @@
     <header>
       <h1>Interface</h1>
       <p class="intro">
-        Struggling to keep up with your coursework? This tool helps students tackle heavy workloads and fast-paced schedules by providing instant, focused study support. No more wasting time searching for resources—just ask, upload your materials, and get clear, actionable answers. Unlock the power of shared knowledge and study smarter, not harder.
+        Struggling to keep up with your coursework? This tool helps students tackle heavy workloads and fast-paced schedules by
+        providing instant, focused study support. No more wasting time searching for resources—just ask, upload your materials,
+        and get clear, actionable answers. Unlock the power of shared knowledge and study smarter, not harder.
       </p>
+      <div class="page-links">
+        <a class="btn secondary" href="{{ url_for('planner') }}">Try Campus Path Planner</a>
+      </div>
     </header>
 
     <section class="row" aria-labelledby="prompt-label">

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Campus Path Planner</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <main class="container planner-container" role="main">
+    <header class="planner-header">
+      <div class="planner-title-group">
+        <h1>Campus Path Planner</h1>
+        <p class="planner-intro">
+          Sketch out your efficient class route. Add your course IDs below and preview where your optimized
+          campus journey will appear once the feature is ready.
+        </p>
+      </div>
+      <a class="btn secondary" href="{{ url_for('index') }}">Back to RAG Assistant</a>
+    </header>
+
+    <section class="planner-grid" aria-labelledby="planner-map-label">
+      <div class="planner-map" role="img" aria-labelledby="planner-map-label planner-map-caption">
+        <p id="planner-map-label" class="planner-section-label">Map Preview</p>
+        <div class="map-placeholder">
+          <span>Campus map overlay coming soon</span>
+        </div>
+        <p id="planner-map-caption" class="planner-caption">This area will display the campus map with your optimized path.</p>
+      </div>
+      <form class="planner-form" aria-labelledby="planner-input-label">
+        <label id="planner-input-label" for="planner-class-input">Class List</label>
+        <textarea id="planner-class-input" name="class-list" placeholder="Enter class IDs, one per line..."></textarea>
+        <button type="button" class="btn" disabled aria-disabled="true">Generate Path (coming soon)</button>
+      </form>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a homepage call-to-action that links directly to the campus path planner
- align button styling for anchors so navigation controls remain visible

## Testing
- python -m compileall app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127bf4bce48328a32d9a72209e6ade)