### PR TITLE
Add annotator page skeleton and link from planner

### DIFF
--- a/routes/planner.py
+++ b/routes/planner.py
@@ -7,3 +7,9 @@ planner_bp = Blueprint("planner", __name__, url_prefix = "/planner")
 def planner():
     """Render the planner template."""
     return render_template("planner.html")
+
+
+@planner_bp.route("/annotator")
+def annotator():
+    """Render the annotator template."""
+    return render_template("annotator.html")

--- a/static/annotator.css
+++ b/static/annotator.css
@@ -1,0 +1,30 @@
+/* Placeholder styles for the annotator page. Customize as needed. */
+
+.annotator-container {
+  padding: 2rem 1.5rem;
+}
+
+.annotator-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.annotator-title-group h1 {
+  margin: 0;
+}
+
+.annotator-title-group p {
+  margin: 0.25rem 0 0;
+  color: #4a5568;
+}
+
+.annotator-placeholder {
+  border: 2px dashed #cbd5e0;
+  border-radius: 0.5rem;
+  padding: 2rem;
+  text-align: center;
+  color: #718096;
+}

--- a/static/annotator.js
+++ b/static/annotator.js
@@ -1,0 +1,8 @@
+// Placeholder script for the annotator page. Add functionality as needed.
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.getElementById('annotator-root');
+  if (root) {
+    root.setAttribute('aria-live', 'polite');
+  }
+});

--- a/templates/annotator.html
+++ b/templates/annotator.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Campus Graph Annotator</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='annotator.css') }}">
+  <script src="{{ url_for('static', filename='annotator.js') }}" defer></script>
+</head>
+<body>
+  <main class="container annotator-container" role="main">
+    <header class="annotator-header">
+      <a href="{{ url_for('planner.planner') }}" class="btn secondary back-button">← Back to Planner</a>
+      <div class="annotator-title-group">
+        <h1>Campus Graph Annotator</h1>
+        <p class="annotator-intro">Prepare custom map overlays and annotations for your campus routes.</p>
+      </div>
+    </header>
+
+    <section class="annotator-content" aria-labelledby="annotator-root">
+      <main id="annotator-root" class="annotator-placeholder">
+        <!-- Annotator tool will be embedded here. -->
+        <p>Annotator tool will go here.</p>
+      </main>
+    </section>
+  </main>
+</body>
+</html>

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -16,7 +16,10 @@
           campus journey will appear once the feature is ready.
         </p>
       </div>
-      <a class="btn secondary" href="{{ url_for('rag.rag') }}">Back to RAG Assistant</a>
+      <div class="planner-actions">
+        <a class="btn secondary" href="{{ url_for('planner.annotator') }}">Use Custom Map Annotator</a>
+        <a class="btn secondary" href="{{ url_for('rag.rag') }}">Back to RAG Assistant</a>
+      </div>
     </header>
 
     <section class="planner-grid" aria-labelledby="planner-map-label">


### PR DESCRIPTION
## Summary
- add an annotator endpoint to the planner blueprint and render a new annotator template
- create a minimal annotator page layout with placeholder content and stubbed static assets
- add navigation from the planner page to the new annotator view

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928a48fd00083288a32283e86b953fd)