### PR TITLE
Improve annotator layout spacing

### DIFF
--- a/static/annotator.css
+++ b/static/annotator.css
@@ -49,7 +49,7 @@
   flex: 1;
   min-height: 0;
   display: flex;
-  padding: 1.5rem;
+  padding: 0.75rem 1rem;
   overflow: auto;
 }
 
@@ -123,9 +123,11 @@ body {
 #main-layout {
   flex: 1;
   display: grid;
-  grid-template-columns: 260px minmax(0, 1fr) 320px;
+  grid-template-columns: clamp(220px, 24vw, 280px) minmax(0, 1fr) clamp(260px, 26vw, 340px);
   grid-template-rows: 1fr;
   min-height: 0;
+  gap: 0.75rem;
+  padding: 0.25rem;
 }
 
 #left-panel,
@@ -137,6 +139,7 @@ body {
   flex-direction: column;
   gap: 0.5rem;
   overflow: auto;
+  min-width: 0;
 }
 
 #right-panel {


### PR DESCRIPTION
## Summary
- reduce padding around the annotator shell to free up viewport space
- adjust panel grid widths with responsive clamps and spacing so the canvas area can expand

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928bdb9dfe8832880248c4c64348120)