### PR TITLE
Position annotator toolbar beneath header

### DIFF
--- a/static/annotator.css
+++ b/static/annotator.css
@@ -17,7 +17,6 @@
   box-shadow: none;
   min-height: 100vh;
   height: 100vh;
-  padding-top: var(--annotator-header-height);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -49,7 +48,7 @@
   flex: 1;
   min-height: 0;
   display: flex;
-  padding: 1.5rem;
+  padding: 0.75rem 1rem;
   overflow: auto;
 }
 
@@ -57,16 +56,14 @@
 .annotator-placeholder {
   flex: 1;
   min-height: 0;
-  border: 2px dashed #cbd5e0;
-  border-radius: 0.75rem;
-  padding: 2rem;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  color: #718096;
-  background: #ffffff;
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.05);
+  flex-direction: column;
+  align-items: stretch;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 /* Core annotator tool styling (your dark UI) */
@@ -90,16 +87,20 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
 }
 
 #top-bar {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.4rem 0.8rem;
+  padding: 0.6rem 0.9rem;
   background: #2a2d30;
   border-bottom: 1px solid #444;
   font-size: 0.9rem;
+  position: sticky;
+  top: var(--annotator-header-height);
+  z-index: 5;
 }
 
 #top-bar button {
@@ -123,9 +124,11 @@ body {
 #main-layout {
   flex: 1;
   display: grid;
-  grid-template-columns: 260px minmax(0, 1fr) 320px;
+  grid-template-columns: clamp(220px, 24vw, 280px) minmax(0, 1fr) clamp(260px, 26vw, 340px);
   grid-template-rows: 1fr;
   min-height: 0;
+  gap: 0.75rem;
+  padding: 0.25rem;
 }
 
 #left-panel,
@@ -137,6 +140,7 @@ body {
   flex-direction: column;
   gap: 0.5rem;
   overflow: auto;
+  min-width: 0;
 }
 
 #right-panel {


### PR DESCRIPTION
## Summary
- remove the annotator container padding that was pushing content below the fixed header
- offset the toolbar’s sticky position by the header height so it appears directly beneath the white header

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928bdb9dfe8832880248c4c64348120)