### PR TITLE
Implement campus path planner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY app.py .
 COPY templates/ ./templates/
 COPY static/ ./static/
 COPY routes/ ./routes/
+COPY resources/ ./resources/
 
 # Copy API keys and RAG documents directories
 # These will be included in the image so they persist across container instances

--- a/routes/planner.py
+++ b/routes/planner.py
@@ -75,6 +75,7 @@ def _build_adjacency(graph: dict) -> Dict[str, List[Tuple[str, float]]]:
         if from_node not in adjacency or to_node not in adjacency:
             continue
         adjacency[from_node].append((to_node, travel_time))
+        adjacency[to_node].append((from_node, travel_time))
 
     return adjacency
 

--- a/routes/planner.py
+++ b/routes/planner.py
@@ -1,12 +1,245 @@
-"""Blueprint for the planner route."""
-from flask import Blueprint, render_template
+"""Blueprint and logic for the campus path planner."""
+from __future__ import annotations
 
-planner_bp = Blueprint("planner", __name__, url_prefix = "/planner")
+import heapq
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from flask import (
+    Blueprint,
+    jsonify,
+    render_template,
+    request,
+    send_from_directory,
+    url_for,
+)
+
+planner_bp = Blueprint("planner", __name__, url_prefix="/planner")
+
+_RESOURCE_DIR = Path(__file__).resolve().parent.parent / "resources"
+_GRAPH_PATH = _RESOURCE_DIR / "campus-graph-20251127-initial-edges.json"
+
+_graph_cache: Optional[dict] = None
+_adjacency_cache: Optional[Dict[str, List[Tuple[str, float]]]] = None
+_nodes_by_id: Optional[Dict[str, dict]] = None
+_buildings_by_id: Optional[Dict[str, dict]] = None
+
+
+def _load_graph() -> dict:
+    """Load and cache the campus graph definition."""
+    global _graph_cache, _nodes_by_id, _buildings_by_id
+    if _graph_cache is None:
+        with _GRAPH_PATH.open("r", encoding="utf-8") as graph_file:
+            _graph_cache = json.load(graph_file)
+        _nodes_by_id = {node["id"]: node for node in _graph_cache.get("nodes", [])}
+        _buildings_by_id = {bldg["id"]: bldg for bldg in _graph_cache.get("buildings", [])}
+    return _graph_cache
+
+
+def _edge_travel_time(edge: dict, settings: dict, blocked_edge_ids: set) -> Optional[float]:
+    """Return the travel time for an edge or ``None`` if blocked."""
+    flags = edge.get("flags", {})
+    if flags.get("blocked"):
+        return None
+    if edge.get("id") in blocked_edge_ids:
+        return None
+
+    base_time_s = edge["length_m"] / settings["walking_speed_mps"]
+    penalty = edge.get("penalty_s", 0)
+
+    penalties = settings.get("penalties", {})
+    if flags.get("stairs"):
+        penalty += penalties.get("stairs_s", 0)
+    if flags.get("steep"):
+        penalty += penalties.get("steep_s", 0)
+    if flags.get("covered"):
+        penalty += penalties.get("covered_s", 0)
+
+    return base_time_s + penalty
+
+
+def _build_adjacency(graph: dict) -> Dict[str, List[Tuple[str, float]]]:
+    """Construct an adjacency list keyed by node id."""
+    settings = graph.get("settings", {})
+    blocked_edge_ids = set(graph.get("overrides", {}).get("blockedEdgeIds", []))
+
+    adjacency: Dict[str, List[Tuple[str, float]]] = {node["id"]: [] for node in graph.get("nodes", [])}
+
+    for edge in graph.get("edges", []):
+        travel_time = _edge_travel_time(edge, settings, blocked_edge_ids)
+        if travel_time is None:
+            continue
+        from_node = edge.get("from")
+        to_node = edge.get("to")
+        if from_node not in adjacency or to_node not in adjacency:
+            continue
+        adjacency[from_node].append((to_node, travel_time))
+
+    return adjacency
+
+
+def _get_adjacency() -> Dict[str, List[Tuple[str, float]]]:
+    """Return a cached adjacency list for the graph."""
+    global _adjacency_cache
+    if _adjacency_cache is None:
+        graph = _load_graph()
+        _adjacency_cache = _build_adjacency(graph)
+    return _adjacency_cache
+
+
+def _dijkstra(
+    start: str, goal: str, adjacency: Dict[str, List[Tuple[str, float]]]
+) -> Tuple[Optional[float], List[str]]:
+    """Compute the shortest path using Dijkstra's algorithm."""
+    queue: List[Tuple[float, str]] = [(0.0, start)]
+    distances: Dict[str, float] = {start: 0.0}
+    previous: Dict[str, Optional[str]] = {start: None}
+
+    while queue:
+        current_distance, node = heapq.heappop(queue)
+        if node == goal:
+            break
+        if current_distance > distances.get(node, float("inf")):
+            continue
+        for neighbor, weight in adjacency.get(node, []):
+            distance = current_distance + weight
+            if distance < distances.get(neighbor, float("inf")):
+                distances[neighbor] = distance
+                previous[neighbor] = node
+                heapq.heappush(queue, (distance, neighbor))
+
+    if goal not in previous:
+        return None, []
+
+    path: List[str] = []
+    node: Optional[str] = goal
+    while node is not None:
+        path.append(node)
+        node = previous.get(node)
+    path.reverse()
+
+    return distances.get(goal), path
+
+
+def _shortest_path_between_buildings(
+    building_start: str, building_end: str, adjacency: Dict[str, List[Tuple[str, float]]]
+) -> Tuple[Optional[float], List[str]]:
+    """Evaluate all entrance pairs to find the fastest building-to-building path."""
+    building_a = _buildings_by_id.get(building_start, {}) if _buildings_by_id else {}
+    building_b = _buildings_by_id.get(building_end, {}) if _buildings_by_id else {}
+
+    best_time: Optional[float] = None
+    best_path: List[str] = []
+
+    for start_node in building_a.get("entranceNodeIds", []):
+        for end_node in building_b.get("entranceNodeIds", []):
+            time_s, path = _dijkstra(start_node, end_node, adjacency)
+            if time_s is None or not path:
+                continue
+            if best_time is None or time_s < best_time:
+                best_time = time_s
+                best_path = path
+
+    return best_time, best_path
+
 
 @planner_bp.route("/")
 def planner():
-    """Render the planner template."""
-    return render_template("planner.html")
+    """Render the planner template with building metadata."""
+    graph = _load_graph()
+    buildings = graph.get("buildings", [])
+    image = graph.get("image", {})
+
+    return render_template(
+        "planner.html",
+        buildings=[{"id": b.get("id"), "name": b.get("name")} for b in buildings],
+        image={"width_px": image.get("width_px"), "height_px": image.get("height_px")},
+    )
+
+
+@planner_bp.route("/route", methods=["POST"])
+def compute_route():
+    """Compute the campus walking route for the given buildings."""
+    graph = _load_graph()
+    adjacency = _get_adjacency()
+
+    data = request.get_json(force=True, silent=True) or {}
+    building_codes: List[str] = data.get("buildings", [])
+
+    if not isinstance(building_codes, list) or not building_codes:
+        return jsonify({"error": "Request must include a list of building codes."}), 400
+
+    invalid_codes = [code for code in building_codes if code not in (_buildings_by_id or {})]
+    if invalid_codes:
+        return (
+            jsonify({"error": f"Unknown building codes: {', '.join(invalid_codes)}"}),
+            400,
+        )
+
+    if len(building_codes) < 2:
+        return jsonify({"error": "Provide at least two building codes to plan a route."}), 400
+
+    legs = []
+    total_time_s = 0.0
+    combined_path: List[str] = []
+
+    for start_code, end_code in zip(building_codes, building_codes[1:]):
+        leg_time, node_path = _shortest_path_between_buildings(start_code, end_code, adjacency)
+        if leg_time is None or not node_path:
+            return (
+                jsonify({"error": f"No available path between {start_code} and {end_code}."}),
+                400,
+            )
+
+        total_time_s += leg_time
+
+        if combined_path and node_path and combined_path[-1] == node_path[0]:
+            combined_path.extend(node_path[1:])
+        else:
+            combined_path.extend(node_path)
+
+        polyline = [
+            {"x": _nodes_by_id[node_id]["x"], "y": _nodes_by_id[node_id]["y"]}
+            for node_id in node_path
+            if node_id in (_nodes_by_id or {})
+        ]
+
+        if polyline:
+            avg_x = sum(point["x"] for point in polyline) / len(polyline)
+            avg_y = sum(point["y"] for point in polyline) / len(polyline)
+        else:
+            avg_x = avg_y = 0
+
+        legs.append(
+            {
+                "from_building": start_code,
+                "to_building": end_code,
+                "time_s": leg_time,
+                "polyline": polyline,
+                "label_position": {"x": avg_x, "y": avg_y},
+            }
+        )
+
+    image = graph.get("image", {})
+
+    return jsonify(
+        {
+            "image": {
+                "width_px": image.get("width_px"),
+                "height_px": image.get("height_px"),
+                "url": url_for("planner.campus_map"),
+            },
+            "legs": legs,
+            "total_time_s": total_time_s,
+        }
+    )
+
+
+@planner_bp.route("/campus-map")
+def campus_map():
+    """Serve the campus map image used by the planner."""
+    return send_from_directory(_RESOURCE_DIR, "campus-map.png")
 
 
 @planner_bp.route("/annotator")

--- a/routes/rag.py
+++ b/routes/rag.py
@@ -14,7 +14,7 @@ import pdfplumber
 from docx import Document as DocxDocument
 from pptx import Presentation
 from bs4 import BeautifulSoup
-from flask import Blueprint, Response, jsonify, request, stream_with_context, render_template
+from flask import Blueprint, Response, jsonify, request, stream_with_context, render_template, redirect, url_for
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage
 from langchain_google_genai import ChatGoogleGenerativeAI
@@ -239,12 +239,8 @@ def set_environment_api_key(llm_choice: str, api_key: str):
 
 @rag_bp.route("/planner")
 def planner():
-    """Placeholder route for planner (some templates reference this)."""
-    try:
-        return render_template("planner.html")
-    except Exception:
-        # Fallback simple response if the planner template isn't present
-        return "Planner page (template missing).", 200
+    """Redirect to the dedicated planner blueprint."""
+    return redirect(url_for("planner.planner"))
 
 
 @rag_bp.route('/notes')

--- a/static/planner.css
+++ b/static/planner.css
@@ -2,13 +2,20 @@
   position: relative;
   display: inline-block;
   width: 100%;
+  overflow: hidden;
+}
+
+.map-canvas {
+  position: relative;
+  display: block;
+  width: 100%;
+  transform-origin: top left;
 }
 
 .map-wrapper img {
   display: block;
   width: 100%;
   height: auto;
-  transform-origin: top left;
 }
 
 .route-overlay {
@@ -17,7 +24,6 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  transform-origin: top left;
 }
 
 .building-key {

--- a/static/planner.css
+++ b/static/planner.css
@@ -1,20 +1,11 @@
 .map-wrapper {
   position: relative;
   display: inline-block;
-  width: 100%;
-  overflow: hidden;
-}
-
-.map-canvas {
-  position: relative;
-  display: block;
-  width: 100%;
-  transform-origin: top left;
 }
 
 .map-wrapper img {
   display: block;
-  width: 100%;
+  max-width: 100%;
   height: auto;
 }
 

--- a/static/planner.css
+++ b/static/planner.css
@@ -8,6 +8,7 @@
   display: block;
   width: 100%;
   height: auto;
+  transform-origin: top left;
 }
 
 .route-overlay {
@@ -16,6 +17,7 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
+  transform-origin: top left;
 }
 
 .building-key {

--- a/static/planner.css
+++ b/static/planner.css
@@ -1,0 +1,61 @@
+.map-wrapper {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.map-wrapper img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.route-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.building-key {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  padding: 1rem;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.building-key h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.building-key ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.building-key code {
+  font-weight: 700;
+}
+
+.planner-actions-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (min-width: 640px) {
+  .planner-actions-row {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}

--- a/static/planner.js
+++ b/static/planner.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const totalTimeEl = document.getElementById('planner-total-time');
   const mapImage = document.getElementById('campus-map');
   const mapWrapper = document.querySelector('.map-wrapper');
+  const mapCanvas = document.querySelector('.map-canvas');
 
   const clearOverlay = () => {
     if (overlay) {
@@ -13,11 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const resetView = () => {
-    if (overlay) {
-      overlay.style.transform = '';
-    }
-    if (mapImage) {
-      mapImage.style.transform = '';
+    if (mapCanvas) {
+      mapCanvas.style.transform = '';
     }
   };
 
@@ -34,8 +32,8 @@ document.addEventListener('DOMContentLoaded', () => {
       return null;
     }
 
-    const displayWidth = mapWrapper?.clientWidth || mapImage.clientWidth || width;
-    const displayHeight = mapWrapper?.clientHeight || mapImage.clientHeight || height;
+    const displayWidth = mapCanvas?.clientWidth || mapWrapper?.clientWidth || mapImage.clientWidth || width;
+    const displayHeight = mapCanvas?.clientHeight || mapWrapper?.clientHeight || mapImage.clientHeight || height;
 
     return { width, height, displayWidth, displayHeight };
   };
@@ -115,11 +113,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
 
-    if (overlay) {
-      overlay.style.transform = transform;
-    }
-    if (mapImage) {
-      mapImage.style.transform = transform;
+    if (mapCanvas) {
+      mapCanvas.style.transform = transform;
     }
   };
 

--- a/static/planner.js
+++ b/static/planner.js
@@ -1,0 +1,103 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const buildingInput = document.getElementById('planner-building-input');
+  const generateBtn = document.getElementById('btn-generate-route');
+  const overlay = document.getElementById('route-overlay');
+  const totalTimeEl = document.getElementById('planner-total-time');
+
+  const clearOverlay = () => {
+    if (overlay) {
+      overlay.innerHTML = '';
+    }
+  };
+
+  const renderLeg = (leg) => {
+    if (!overlay || !leg?.polyline?.length) {
+      return;
+    }
+
+    const points = leg.polyline.map((p) => `${p.x},${p.y}`).join(' ');
+    const polyline = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+    polyline.setAttribute('points', points);
+    polyline.setAttribute('fill', 'none');
+    polyline.setAttribute('stroke', '#2c7be5');
+    polyline.setAttribute('stroke-width', '4');
+    polyline.setAttribute('stroke-linejoin', 'round');
+    polyline.setAttribute('stroke-linecap', 'round');
+
+    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    const minutes = (leg.time_s / 60).toFixed(1) + ' min';
+    text.textContent = minutes;
+    text.setAttribute('x', leg.label_position?.x ?? 0);
+    text.setAttribute('y', (leg.label_position?.y ?? 0) - 8);
+    text.setAttribute('fill', '#1b2838');
+    text.setAttribute('font-size', '16');
+    text.setAttribute('font-weight', '600');
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('dominant-baseline', 'central');
+    text.setAttribute('paint-order', 'stroke');
+    text.setAttribute('stroke', 'white');
+    text.setAttribute('stroke-width', '2');
+
+    overlay.appendChild(polyline);
+    overlay.appendChild(text);
+  };
+
+  const showError = (message) => {
+    if (totalTimeEl) {
+      totalTimeEl.textContent = message;
+    }
+    clearOverlay();
+  };
+
+  const handleGenerate = async () => {
+    if (!buildingInput) {
+      showError('Planner input is unavailable.');
+      return;
+    }
+
+    const codes = buildingInput.value
+      .split('\n')
+      .map((code) => code.trim())
+      .filter((code) => code.length > 0);
+
+    if (codes.length < 2) {
+      showError('Enter at least two building codes.');
+      return;
+    }
+
+    try {
+      const response = await fetch('/planner/route', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ buildings: codes }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        const errorMsg = errorData.error || 'Unable to compute route.';
+        showError(errorMsg);
+        return;
+      }
+
+      const data = await response.json();
+      clearOverlay();
+
+      if (Array.isArray(data.legs)) {
+        data.legs.forEach(renderLeg);
+      }
+
+      if (totalTimeEl && typeof data.total_time_s === 'number') {
+        const minutes = (data.total_time_s / 60).toFixed(1);
+        totalTimeEl.textContent = `Total time: ${minutes} min`;
+      }
+    } catch (err) {
+      showError('An unexpected error occurred while fetching the route.');
+    }
+  };
+
+  if (generateBtn) {
+    generateBtn.addEventListener('click', handleGenerate);
+  }
+});

--- a/static/planner.js
+++ b/static/planner.js
@@ -3,39 +3,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const generateBtn = document.getElementById('btn-generate-route');
   const overlay = document.getElementById('route-overlay');
   const totalTimeEl = document.getElementById('planner-total-time');
-  const mapImage = document.getElementById('campus-map');
-  const mapWrapper = document.querySelector('.map-wrapper');
-  const mapCanvas = document.querySelector('.map-canvas');
 
   const clearOverlay = () => {
     if (overlay) {
       overlay.innerHTML = '';
     }
-  };
-
-  const resetView = () => {
-    if (mapCanvas) {
-      mapCanvas.style.transform = '';
-    }
-  };
-
-  const getMapDimensions = () => {
-    if (!overlay || !mapImage) {
-      return null;
-    }
-
-    const viewBox = overlay.viewBox?.baseVal;
-    const width = viewBox?.width || mapImage.naturalWidth || mapImage.width;
-    const height = viewBox?.height || mapImage.naturalHeight || mapImage.height;
-
-    if (!width || !height) {
-      return null;
-    }
-
-    const displayWidth = mapCanvas?.clientWidth || mapWrapper?.clientWidth || mapImage.clientWidth || width;
-    const displayHeight = mapCanvas?.clientHeight || mapWrapper?.clientHeight || mapImage.clientHeight || height;
-
-    return { width, height, displayWidth, displayHeight };
   };
 
   const renderLeg = (leg) => {
@@ -70,60 +42,11 @@ document.addEventListener('DOMContentLoaded', () => {
     overlay.appendChild(text);
   };
 
-  const fitToPath = (legs) => {
-    const dims = getMapDimensions();
-    if (!dims || !Array.isArray(legs) || legs.length === 0) {
-      resetView();
-      return;
-    }
-
-    const allPoints = legs.flatMap((leg) => leg.polyline || []);
-    if (!allPoints.length) {
-      resetView();
-      return;
-    }
-
-    const xs = allPoints.map((p) => p.x);
-    const ys = allPoints.map((p) => p.y);
-
-    const minX = Math.min(...xs);
-    const maxX = Math.max(...xs);
-    const minY = Math.min(...ys);
-    const maxY = Math.max(...ys);
-
-    const pathWidth = Math.max(maxX - minX, 1);
-    const pathHeight = Math.max(maxY - minY, 1);
-    const longest = Math.max(pathWidth, pathHeight);
-    const padding = longest; // +100% of the longest dimension total
-
-    const targetMinX = Math.max(0, minX - padding / 2);
-    const targetMaxX = Math.min(dims.width, maxX + padding / 2);
-    const targetMinY = Math.max(0, minY - padding / 2);
-    const targetMaxY = Math.min(dims.height, maxY + padding / 2);
-
-    const targetWidth = Math.max(targetMaxX - targetMinX, 1);
-    const targetHeight = Math.max(targetMaxY - targetMinY, 1);
-
-    const scaleX = dims.displayWidth / targetWidth;
-    const scaleY = dims.displayHeight / targetHeight;
-    const scale = Math.min(scaleX, scaleY);
-
-    const offsetX = (dims.displayWidth - targetWidth * scale) / 2 - targetMinX * scale;
-    const offsetY = (dims.displayHeight - targetHeight * scale) / 2 - targetMinY * scale;
-
-    const transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
-
-    if (mapCanvas) {
-      mapCanvas.style.transform = transform;
-    }
-  };
-
   const showError = (message) => {
     if (totalTimeEl) {
       totalTimeEl.textContent = message;
     }
     clearOverlay();
-    resetView();
   };
 
   const handleGenerate = async () => {
@@ -163,7 +86,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
       if (Array.isArray(data.legs)) {
         data.legs.forEach(renderLeg);
-        fitToPath(data.legs);
       }
 
       if (totalTimeEl && typeof data.total_time_s === 'number') {

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Campus Path Planner</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='planner.css') }}">
+  <script src="{{ url_for('static', filename='planner.js') }}" defer></script>
 </head>
 <body>
   <main class="container planner-container" role="main">
@@ -12,8 +14,8 @@
       <div class="planner-title-group">
         <h1>Campus Path Planner</h1>
         <p class="planner-intro">
-          Sketch out your efficient class route. Add your course IDs below and preview where your optimized
-          campus journey will appear once the feature is ready.
+          Plan the fastest way between your stops. Enter building codes in order and preview the optimized campus
+          route on the map.
         </p>
       </div>
       <div class="planner-actions">
@@ -23,17 +25,39 @@
     </header>
 
     <section class="planner-grid" aria-labelledby="planner-map-label">
-      <div class="planner-map" role="img" aria-labelledby="planner-map-label planner-map-caption">
-        <p id="planner-map-label" class="planner-section-label">Map Preview</p>
-        <div class="map-placeholder">
-          <span>Campus map overlay coming soon</span>
+      <div class="planner-map" aria-labelledby="planner-map-label planner-map-caption">
+        <p id="planner-map-label" class="planner-section-label">Map</p>
+        <div class="map-wrapper">
+          <img id="campus-map"
+               src="{{ url_for('planner.campus_map') }}"
+               width="{{ image.width_px }}"
+               height="{{ image.height_px }}"
+               alt="Campus map" />
+          <svg id="route-overlay"
+               class="route-overlay"
+               viewBox="0 0 {{ image.width_px }} {{ image.height_px }}"
+               preserveAspectRatio="xMidYMid meet"></svg>
         </div>
-        <p id="planner-map-caption" class="planner-caption">This area will display the campus map with your optimized path.</p>
+        <p id="planner-map-caption" class="planner-caption">
+          The map shows the shortest path between your selected buildings.
+        </p>
       </div>
+
       <form class="planner-form" aria-labelledby="planner-input-label">
-        <label id="planner-input-label" for="planner-class-input">Class List</label>
-        <textarea id="planner-class-input" name="class-list" placeholder="Enter class IDs, one per line..."></textarea>
-        <button type="button" class="btn" disabled aria-disabled="true">Generate Path (coming soon)</button>
+        <section class="building-key">
+          <h2>Available Buildings</h2>
+          <ul>
+            {% for b in buildings %}
+              <li><code>{{ b.id }}</code> – {{ b.name }}</li>
+            {% endfor %}
+          </ul>
+        </section>
+        <label id="planner-input-label" for="planner-building-input">Building Codes (in order)</label>
+        <textarea id="planner-building-input" name="building-codes" placeholder="Example:\nBE\nBB\nGC\nCT"></textarea>
+        <div class="planner-actions-row">
+          <button type="button" class="btn" id="btn-generate-route">Generate Path</button>
+          <p class="planner-caption" id="planner-total-time" aria-live="polite"></p>
+        </div>
       </form>
     </section>
   </main>

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -28,17 +28,15 @@
       <div class="planner-map" aria-labelledby="planner-map-label planner-map-caption">
         <p id="planner-map-label" class="planner-section-label">Map</p>
         <div class="map-wrapper">
-          <div class="map-canvas">
-            <img id="campus-map"
-                 src="{{ url_for('planner.campus_map') }}"
-                 width="{{ image.width_px }}"
-                 height="{{ image.height_px }}"
-                 alt="Campus map" />
-            <svg id="route-overlay"
-                 class="route-overlay"
-                 viewBox="0 0 {{ image.width_px }} {{ image.height_px }}"
-                 preserveAspectRatio="xMidYMid meet"></svg>
-          </div>
+          <img id="campus-map"
+               src="{{ url_for('planner.campus_map') }}"
+               width="{{ image.width_px }}"
+               height="{{ image.height_px }}"
+               alt="Campus map" />
+          <svg id="route-overlay"
+               class="route-overlay"
+               viewBox="0 0 {{ image.width_px }} {{ image.height_px }}"
+               preserveAspectRatio="xMidYMid meet"></svg>
         </div>
         <p id="planner-map-caption" class="planner-caption">
           The map shows the shortest path between your selected buildings.

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -28,15 +28,17 @@
       <div class="planner-map" aria-labelledby="planner-map-label planner-map-caption">
         <p id="planner-map-label" class="planner-section-label">Map</p>
         <div class="map-wrapper">
-          <img id="campus-map"
-               src="{{ url_for('planner.campus_map') }}"
-               width="{{ image.width_px }}"
-               height="{{ image.height_px }}"
-               alt="Campus map" />
-          <svg id="route-overlay"
-               class="route-overlay"
-               viewBox="0 0 {{ image.width_px }} {{ image.height_px }}"
-               preserveAspectRatio="xMidYMid meet"></svg>
+          <div class="map-canvas">
+            <img id="campus-map"
+                 src="{{ url_for('planner.campus_map') }}"
+                 width="{{ image.width_px }}"
+                 height="{{ image.height_px }}"
+                 alt="Campus map" />
+            <svg id="route-overlay"
+                 class="route-overlay"
+                 viewBox="0 0 {{ image.width_px }} {{ image.height_px }}"
+                 preserveAspectRatio="xMidYMid meet"></svg>
+          </div>
         </div>
         <p id="planner-map-caption" class="planner-caption">
           The map shows the shortest path between your selected buildings.


### PR DESCRIPTION
## Summary
- load the campus graph, build adjacency with penalties, and expose route and map endpoints for the planner
- update the planner page to show building codes, accept ordered inputs, and render the campus map overlay
- add planner-specific JavaScript and styles to draw computed legs and display total travel time

## Testing
- python -m compileall routes static templates

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928c88b99f08328a6bbabab5a66f31f)